### PR TITLE
Added comparison for CSM image to ground, ISIS ground to image

### DIFF
--- a/examples/kaguya_tc_isis_cmp.ipynb
+++ b/examples/kaguya_tc_isis_cmp.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pyproj\n",
     "import pvl\n",
     "import numpy as np\n",
     "import os\n",
@@ -83,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def check_pixel(camera, cub, line, sample):\n",
+    "def check_pixel_isis_ground(camera, cub, line, sample):\n",
     "    \"\"\"Compares ISIS and USGSCSM pixel.\n",
     "    \n",
     "    Takes an image coordinate, projects it to a ground point using ISIS, then projects\n",
@@ -94,6 +95,7 @@
     "    pvl_output = pvl.loads(output)\n",
     "    bodyfixed = pvl_output['GroundPoint']['BodyFixedCoordinate']\n",
     "    bodyfixed = np.asarray(bodyfixed.value) * 1000\n",
+    "    coord = csmapi.EcefCoord(*bodyfixed)\n",
     "    image_coord = camera.groundToImage(csmapi.EcefCoord(*bodyfixed))\n",
     "    # (.5,.5) in CSM == (1,1) in ISIS, so we have to subtract (.5,.5) from the ISIS pixels\n",
     "    line_diff = line - image_coord.line - .5\n",
@@ -128,11 +130,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ecef_to_lla(x, y, z, a_radius, b_radius):\n",
+    "    \"\"\" Converts from earth-centric, earth-fixed to lat, lon, altitude\n",
+    "    \"\"\"\n",
+    "    ecef = pyproj.Proj(proj='geocent', a=a_radius, b=b_radius)\n",
+    "    lla = pyproj.Proj(proj='latlong',  a=a_radius, b=b_radius)\n",
+    "    \n",
+    "    lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)\n",
+    "    return lon, lat, alt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_pixel_csm_ground(camera, cub, line, sample):\n",
+    "    \"\"\"Compares ISIS and USGSCSM pixel.\n",
+    "    \n",
+    "    Takes an image coordinate, projects it to a ground point using CSM, then projects\n",
+    "    the result back into an image coordinate using ISIS and computes the difference\n",
+    "    between image coordinates.\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    # Create an image coordinate based on line and sample\n",
+    "    image_coord = csmapi.ImageCoord(line, sample)\n",
+    "    # Project image coordinate to a ground point\n",
+    "    out = camera.imageToGround(image_coord, 0.0)\n",
+    "    \n",
+    "    # Results of imageToGround are ECEF, campt requires lat/lon\n",
+    "    a_rad, b_rad = knoten.csm.get_radii(camera)\n",
+    "    lon,lat,_ = ecef_to_lla(out.x, out.y, out.z, a_rad, b_rad)\n",
+    "\n",
+    "    # campt requires positive east 360\n",
+    "    lon = (lon+360)%360\n",
+    "    \n",
+    "    try:\n",
+    "        pvl_output = isis.campt(from_=cub_loc, type='ground', latitude=lat, longitude=lon, allowoutside=True)\n",
+    "        output = pvl.loads(pvl_output)\n",
+    "        isis_line = output['GroundPoint']['Line']\n",
+    "        isis_sample = output['GroundPoint']['Sample']\n",
+    "        # (.5,.5) in CSM == (1,1) in ISIS, so we have to add (.5,.5) to the ISIS pixels\n",
+    "        line_diff = line - isis_line +.5\n",
+    "        sample_diff = sample - isis_sample +.5\n",
+    "    except ProcessError as e:\n",
+    "        print(f'({line}, {sample}): {e.stderr}')\n",
+    "        line_diff = np.NaN\n",
+    "        sample_diff = np.NaN\n",
+    "        \n",
+    "    return line_diff, sample_diff\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(4656.0, 1.0): b'**ERROR** Requested position does not project in camera model; no surface intersection.\\n'\n",
+      "(4656.0, 1744.0): b'**ERROR** Requested position does not project in camera model; no surface intersection.\\n'\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -156,8 +225,10 @@
        "      <th></th>\n",
        "      <th>line</th>\n",
        "      <th>sample</th>\n",
-       "      <th>line_diff</th>\n",
-       "      <th>sample_diff</th>\n",
+       "      <th>line_diff_csm_ground</th>\n",
+       "      <th>sample_diff_csm_ground</th>\n",
+       "      <th>line_diff_isis_ground</th>\n",
+       "      <th>sample_diff_isis_ground</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -165,6 +236,8 @@
        "      <th>0</th>\n",
        "      <td>1.0</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>-0.408429</td>\n",
+       "      <td>-1.081255</td>\n",
        "      <td>0.610291</td>\n",
        "      <td>1.079313</td>\n",
        "    </tr>\n",
@@ -172,6 +245,8 @@
        "      <th>1</th>\n",
        "      <td>1.0</td>\n",
        "      <td>1744.0</td>\n",
+       "      <td>-0.407672</td>\n",
+       "      <td>-0.989566</td>\n",
        "      <td>0.610945</td>\n",
        "      <td>0.992453</td>\n",
        "    </tr>\n",
@@ -179,6 +254,8 @@
        "      <th>2</th>\n",
        "      <td>4656.0</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>-1.548140</td>\n",
        "      <td>1.099806</td>\n",
        "    </tr>\n",
@@ -186,6 +263,8 @@
        "      <th>3</th>\n",
        "      <td>4656.0</td>\n",
        "      <td>1744.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>-1.547574</td>\n",
        "      <td>0.963186</td>\n",
        "    </tr>\n",
@@ -193,6 +272,8 @@
        "      <th>4</th>\n",
        "      <td>2328.0</td>\n",
        "      <td>872.0</td>\n",
+       "      <td>-0.413635</td>\n",
+       "      <td>-1.034119</td>\n",
        "      <td>-1.542982</td>\n",
        "      <td>1.032304</td>\n",
        "    </tr>\n",
@@ -201,15 +282,22 @@
        "</div>"
       ],
       "text/plain": [
-       "     line  sample  line_diff  sample_diff\n",
-       "0     1.0     1.0   0.610291     1.079313\n",
-       "1     1.0  1744.0   0.610945     0.992453\n",
-       "2  4656.0     1.0  -1.548140     1.099806\n",
-       "3  4656.0  1744.0  -1.547574     0.963186\n",
-       "4  2328.0   872.0  -1.542982     1.032304"
+       "     line  sample  line_diff_csm_ground  sample_diff_csm_ground  \\\n",
+       "0     1.0     1.0             -0.408429               -1.081255   \n",
+       "1     1.0  1744.0             -0.407672               -0.989566   \n",
+       "2  4656.0     1.0                   NaN                     NaN   \n",
+       "3  4656.0  1744.0                   NaN                     NaN   \n",
+       "4  2328.0   872.0             -0.413635               -1.034119   \n",
+       "\n",
+       "   line_diff_isis_ground  sample_diff_isis_ground  \n",
+       "0               0.610291                 1.079313  \n",
+       "1               0.610945                 0.992453  \n",
+       "2              -1.548140                 1.099806  \n",
+       "3              -1.547574                 0.963186  \n",
+       "4              -1.542982                 1.032304  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,12 +306,16 @@
     "pixels_dict = {'line' : [1,1,n_lines, n_lines, n_lines/2],\n",
     "               'sample' : [1, n_samples, 1, n_samples, n_samples/2]}\n",
     "\n",
+    "# Create a dataframe to store the results of pixel comparison\n",
     "pixels_df = pd.DataFrame.from_dict(pixels_dict)\n",
-    "pixels_df['line_diff'] = np.NaN\n",
-    "pixels_df['sample_diff'] = np.NaN\n",
+    "pixels_df['line_diff_csm_ground'] = np.NaN\n",
+    "pixels_df['sample_diff_csm_ground'] = np.NaN\n",
+    "pixels_df['line_diff_isis_ground'] = np.NaN\n",
+    "pixels_df['sample_diff_isis_ground'] = np.NaN\n",
     "\n",
     "for idx, row in pixels_df.iterrows():\n",
-    "    pixels_df.iloc[idx]['line_diff'], pixels_df.iloc[idx]['sample_diff'] = check_pixel(camera, cub_loc, row['line'], row['sample'])\n",
+    "    pixels_df.iloc[idx]['line_diff_isis_ground'], pixels_df.iloc[idx]['sample_diff_isis_ground'] = check_pixel_isis_ground(camera, cub_loc, row['line'], row['sample'])\n",
+    "    pixels_df.iloc[idx]['line_diff_csm_ground'], pixels_df.iloc[idx]['sample_diff_csm_ground'] = check_pixel_csm_ground(camera, cub_loc, row['line'], row['sample'])\n",
     "\n",
     "pixels_df"
    ]

--- a/examples/kaguya_tc_isis_cmp.ipynb
+++ b/examples/kaguya_tc_isis_cmp.ipynb
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
     "        output = pvl.loads(pvl_output)\n",
     "        isis_line = output['GroundPoint']['Line']\n",
     "        isis_sample = output['GroundPoint']['Sample']\n",
-    "        # (.5,.5) in CSM == (1,1) in ISIS, so we have to add (.5,.5) to the ISIS pixels\n",
+    "        # (.5,.5) in CSM == (1,1) in ISIS, so we have to add (.5,.5) to the CSM pixels\n",
     "        line_diff = line - isis_line +.5\n",
     "        sample_diff = sample - isis_sample +.5\n",
     "    except ProcessError as e:\n",
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/kaguya_tc_isis_cmp.ipynb
+++ b/examples/kaguya_tc_isis_cmp.ipynb
@@ -75,7 +75,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Define a function that compares ISIS and USGSCSM pixels"
+    "## Get the total number of lines / samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "isis_label = pvl.load(cub_loc)\n",
+    "n_samples = isis_label['IsisCube']['Core']['Dimensions']['Samples']\n",
+    "n_lines = isis_label['IsisCube']['Core']['Dimensions']['Lines']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define functions that compare ISIS and USGSCSM pixels"
    ]
   },
   {
@@ -104,49 +122,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Get the total number of lines / samples"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "isis_label = pvl.load(cub_loc)\n",
-    "n_samples = isis_label['IsisCube']['Core']['Dimensions']['Samples']\n",
-    "n_lines = isis_label['IsisCube']['Core']['Dimensions']['Lines']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Compare top left, top right, bottom left, bottom right, and center pixels using check_pixel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def ecef_to_lla(x, y, z, a_radius, b_radius):\n",
-    "    \"\"\" Converts from earth-centric, earth-fixed to lat, lon, altitude\n",
-    "    \"\"\"\n",
-    "    ecef = pyproj.Proj(proj='geocent', a=a_radius, b=b_radius)\n",
-    "    lla = pyproj.Proj(proj='latlong',  a=a_radius, b=b_radius)\n",
-    "    \n",
-    "    lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)\n",
-    "    return lon, lat, alt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +166,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ecef_to_lla(x, y, z, a_radius, b_radius):\n",
+    "    \"\"\" Converts from earth-centric, earth-fixed to lat, lon, altitude\n",
+    "    \"\"\"\n",
+    "    ecef = pyproj.Proj(proj='geocent', a=a_radius, b=b_radius)\n",
+    "    lla = pyproj.Proj(proj='latlong',  a=a_radius, b=b_radius)\n",
+    "    \n",
+    "    lon, lat, alt = pyproj.transform(ecef, lla, x, y, z)\n",
+    "    return lon, lat, alt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare top left, top right, bottom left, bottom right, and center pixels using check_pixel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -297,7 +297,7 @@
        "4              -1.542982                 1.032304  "
       ]
      },
-     "execution_count": 37,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Added an additional test that inverts the ISIS image to ground CSM ground to image processes.  This test uses CSM for image to ground and ISIS for ground to image.

I'm not entirely sure that I got the +.5 pixel value logic correct.  I'd like to verify that this logic is correct before we spend the time adding the tests to the other notebooks.

Additionally, if a point falls outside the footprint of the image, it will not process in campt even with allowoutside=True.  This leads to some NaN values in the final table.