### PR TITLE
updated versions for usgs libs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,9 @@ channels:
   - usgs-astrogeology
   - plotly
 dependencies:
+  - ale>=0.3.2
   - coveralls
-  - csmapi
+  - csmapi>=1.0
   - gdal
   - holoviews
   - jinja2
@@ -24,4 +25,4 @@ dependencies:
   - requests
   - scipy
   - shapely
-  - usgscsm
+  - usgscsm>=1.3.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,9 @@ requirements:
     - python
     - setuptools
   run:
+    - ale>=0.3.2
     - python
-    - csmapi
+    - csmapi>=1.0
     - gdal
     - jinja2
     - numpy
@@ -33,6 +34,7 @@ requirements:
     - requests
     - scipy
     - shapely
+    - usgscsm>=1.3.1
 
 test:
   imports:


### PR DESCRIPTION
This should make sure that install knoten will also install the latest version of the USGS camera model stack. 