### PR TITLE
Updates gdal import and bumps to gdal >= 3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - ale>=0.3.2
   - coveralls
   - csmapi>=1.0
-  - gdal
+  - gdal>=3.0.0
   - holoviews
   - jinja2
   - jupyter

--- a/knoten/csm.py
+++ b/knoten/csm.py
@@ -4,7 +4,7 @@ import os
 
 from csmapi import csmapi
 import jinja2
-from gdal import ogr
+from osgeo import ogr
 import numpy as np
 import pyproj
 import requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - ale>=0.3.2
     - python
     - csmapi>=1.0
-    - gdal
+    - gdal>=3.0.0
     - jinja2
     - numpy
     - plio


### PR DESCRIPTION
This PR updates the gdal import inside of knoten to support the 'new' again `from osgeo` style import. This also forces gdal >=3.