### PR TITLE
Adds surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
           environment-file: environment.yml  
           auto-activate-base: false  
           auto-update-conda: true  
-          python-version: ${{ matrix.python-version }} 
+          python-version: ${{ matrix.python-version }}
+      - name: Add test requirements
+        run: |
+          pip install -r requirements_test.txt
       - name: Check build environment
         run: |
           conda list
@@ -41,4 +44,4 @@ jobs:
           python setup.py install
       - name: Test Python Package
         run: |
-           pytest
+           pytest -n4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
           auto-activate-base: false  
           auto-update-conda: true  
           python-version: ${{ matrix.python-version }}
-      - name: Add test requirements
-        run: |
-          pip install -r requirements_test.txt
       - name: Check build environment
         run: |
           conda list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ release.
 ## Unreleased
 
 ### Added
+- `generate_image_coordinate` to `csm.py`. This provides a similar interface to `generate_ground_coordinate` and abstracts away the `csmapi` from the user.
+- A surface class (moved from AutoCNet; credit @jessemapel) with support for Ellipsoid DEMs and basic support for raster DEMs readable by the plio.io.io_gdal.GeoDataset. Support is basic because it uses a single pixel intersection and not an interpolated elevation like ISIS does.
 - A check to `generate_ground_point` when a GeoDataset is used to raise a `ValueError` if the algorithm intersects a no data value in the passed DEM. This ensures that valid heights are used in the intersection computation. Fixes [#120](https://github.com/DOI-USGS/knoten/issues/120)
 
 ### Changed

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - pvl
   - pyproj
   - kalasiris
-  - pytest
   - python>=3
   - requests
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,8 @@ dependencies:
   - plotly-orca 
   - psutil 
   - pvl
+  - pytest
+  - pytest-xdist
   - pyproj
   - kalasiris
   - python>=3

--- a/knoten/csm.py
+++ b/knoten/csm.py
@@ -127,7 +127,7 @@ def generate_ground_point(dem, image_pt, camera):
           GeoDataset object generated from Plio off of a Digital Elevation
           Model (DEM)
     image_pt : tuple
-               Pair of x, y (line, sample) coordinates in pixel space
+               Pair of x, y (sample, line) coordinates in pixel space
     camera : object
              USGSCSM camera model object
     max_its : int, optional

--- a/knoten/surface.py
+++ b/knoten/surface.py
@@ -1,0 +1,145 @@
+"""
+A set of classes that represent the target surface. Each class implements the
+get_height and get_radius functions for computing the height and radius respectively
+at a given ground location (geocentric latitude and longitude).
+"""
+
+import numpy as np
+from plio.io.io_gdal import GeoDataset
+
+class EllipsoidDem:
+    """
+    A biaxial ellipsoid surface model.
+    """
+
+    def __init__(self, semi_major, semi_minor = None):
+        """
+        Create an ellipsoid DEM from a set of radii
+
+        Parameters
+        ----------
+        semi_major : float
+                     The equatorial semi-major radius of the ellipsoid.
+        semi_minor : float
+                     The polar semi-minor radius of the ellipsoid.
+        """
+        self.a = semi_major
+        self.b = semi_major
+        self.c = semi_major
+
+        if semi_minor is not None:
+            self.c = semi_minor
+
+    def get_height(self, lat, lon):
+        """
+        Get the height above the ellipsoid at a ground location
+
+        Parameters
+        ----------
+        lat : float
+              The geocentric latitude in degrees
+        lon : float
+              The longitude in degrees
+        """
+        return 0
+
+    def get_radius(self, lat, lon):
+        """
+        Get the radius at a ground location
+
+        Parameters
+        ----------
+        lat : float
+              The geocentric latitude in degrees
+        lon : float
+              The longitude in degrees
+        """
+        cos_lon = np.cos(np.deg2rad(lon))
+        sin_lon = np.sin(np.deg2rad(lon))
+        cos_lat = np.cos(np.deg2rad(lat))
+        sin_lat = np.sin(np.deg2rad(lat))
+
+        denom = self.b * self.b * cos_lon * cos_lon
+        denom += self.a * self.a * sin_lon * sin_lon
+        denom *= self.c * self.c * cos_lat * cos_lat
+        denom += self.a * self.a * self.b * self.b * sin_lat * sin_lat
+        radius = (self.a * self.b * self.c) / np.sqrt(denom)
+        return radius
+
+class GdalDem(EllipsoidDem):
+    """
+    A raster DEM surface model.
+    """
+
+    def __init__(self, dem, semi_major, semi_minor = None, dem_type=None):
+        """
+        Create a GDAL dem from a dem file
+
+        Parameters
+        ----------
+        dem : str
+              The DEM file
+        semi_major : float
+                     The equatorial semi-major radius of the reference ellipsoid.
+        semi_minor : float
+                     The polar semi-minor radius of the reference ellipsoid.
+        dem_type : str
+                   The type of DEM, either height above reference ellipsoid or radius.
+        """
+        super().__init__(semi_major, semi_minor)
+        dem_types = ('height', 'radius')
+        if dem_type is None:
+            dem_type = dem_types[0]
+        if dem_type not in dem_types:
+            raise ValueError(f'DEM type {dem_type} is not a valid option.')
+        self.dem = GeoDataset(dem)
+        self.dem_type = dem_type
+
+    def get_raster_value(self, lat, lon):
+        """
+        Get the value of the dem raster at a ground location
+
+        Parameters
+        ----------
+        lat : float
+              The geocentric latitude in degrees
+        lon : float
+              The longitude in degrees
+        """
+        px, py = self.dem.latlon_to_pixel(lat, lon)
+        value = self.dem.read_array(1, [px, py, 1, 1])[0][0]
+        if value == self.dem.no_data_value:
+            return None
+        return value
+
+    def get_height(self, lat, lon):
+        """
+        Get the height above the ellipsoid at a ground location
+
+        Parameters
+        ----------
+        lat : float
+              The geocentric latitude in degrees
+        lon : float
+              The longitude in degrees
+        """
+        height = self.get_raster_value(lat, lon)
+        if self.dem_type == 'radius' and height is not None:
+            height -= super().get_radius(lat, lon)
+        return height
+
+    def get_radius(self, lat, lon):
+        """
+        Get the radius at a ground location
+
+        Parameters
+        ----------
+        lat : float
+              The geocentric latitude in degrees
+        lon : float
+              The longitude in degrees
+        """
+        radius = self.get_raster_value(lat, lon)
+        if self.dem_type == 'height':
+            radius += super().get_radius(lat, lon)
+        return radius

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - setuptools
   run:
-    - ale>=0.3.2
+    - ale>=0.10.0
     - python
     - csmapi>=1.0
     - gdal>=3.0.0
@@ -34,7 +34,7 @@ requirements:
     - requests
     - scipy
     - shapely
-    - usgscsm>=1.3.1
+    - usgscsm>=2.0
 
 test:
   imports:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-xdist

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,0 @@
-pytest
-pytest-xdist

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -1,0 +1,68 @@
+import unittest
+
+from unittest import mock
+
+from knoten import surface
+
+class TestEllipsoidDem(unittest.TestCase):
+
+    def test_height(self):
+        test_dem = surface.EllipsoidDem(3396190, 3376200)
+        self.assertEqual(test_dem.get_height(0, 0), 0)
+        self.assertEqual(test_dem.get_height(0, 180), 0)
+        self.assertEqual(test_dem.get_height(90, 100), 0)
+
+    def test_radius(self):
+        test_dem = surface.EllipsoidDem(3396190, 3376200)
+        self.assertEqual(test_dem.get_radius(0, 0), 3396190)
+        self.assertEqual(test_dem.get_radius(0, 180), 3396190)
+        self.assertEqual(test_dem.get_radius(90, 300), 3376200)
+
+    def tearDown(self):
+        pass
+
+
+class TestGdalDem(unittest.TestCase):
+
+    def test_height(self):
+        with mock.patch('knoten.surface.GeoDataset') as mockDataset:
+            mockInstance = mockDataset.return_value
+            mockInstance.latlon_to_pixel.return_value = (1,2)
+            mockInstance.read_array.return_value = [[100]]
+            test_dem = surface.GdalDem('TestDem.cub', 3396190, 3376200)
+            self.assertEqual(test_dem.get_height(0, 0), 100)
+            self.assertEqual(test_dem.get_height(0, 180), 100)
+            self.assertEqual(test_dem.get_height(90, 300), 100)
+
+    def test_height_from_radius(self):
+        with mock.patch('knoten.surface.GeoDataset') as mockDataset:
+            mockInstance = mockDataset.return_value
+            mockInstance.latlon_to_pixel.return_value = (1,2)
+            mockInstance.read_array.return_value = [[3396190]]
+            test_dem = surface.GdalDem('TestDem.cub', 3396190, 3376200, 'radius')
+            self.assertEqual(test_dem.get_height(0, 0), 0)
+            self.assertEqual(test_dem.get_height(0, 180), 0)
+            self.assertEqual(test_dem.get_height(90, 300), 19990)
+
+    def test_radius(self):
+        with mock.patch('knoten.surface.GeoDataset') as mockDataset:
+            mockInstance = mockDataset.return_value
+            mockInstance.latlon_to_pixel.return_value = (1,2)
+            mockInstance.read_array.return_value = [[3396190]]
+            test_dem = surface.GdalDem('TestDem.cub', 3396190, 3376200, 'radius')
+            self.assertEqual(test_dem.get_radius(0, 0), 3396190)
+            self.assertEqual(test_dem.get_radius(0, 180), 3396190)
+            self.assertEqual(test_dem.get_radius(90, 300), 3396190)
+
+    def test_radius_from_height(self):
+        with mock.patch('knoten.surface.GeoDataset') as mockDataset:
+            mockInstance = mockDataset.return_value
+            mockInstance.latlon_to_pixel.return_value = (1,2)
+            mockInstance.read_array.return_value = [[100]]
+            test_dem = surface.GdalDem(mockInstance, 3396190, 3376200)
+            self.assertEqual(test_dem.get_radius(0, 0), 3396290)
+            self.assertEqual(test_dem.get_radius(0, 180), 3396290)
+            self.assertEqual(test_dem.get_radius(90, 300), 3376300)
+
+    def tearDown(self):
+        pass


### PR DESCRIPTION
This PR adds a surface class, originally implemented in AutoCNet by @jessemapel. I have moved this class into knoten as this seems to be a more natural home. Having a surface is necessary for sensor model operations with the CSM. This PR adds the surface classes, tests, updated `csm` to use the surface, and updates the CSM tests to use the surface models.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

